### PR TITLE
Don't wait for machine to boot

### DIFF
--- a/glesys.go
+++ b/glesys.go
@@ -209,21 +209,6 @@ func (d *Driver) Create() error {
 	}
 
 	d.ServerID = server.ID
-
-	log.Info("Waiting for machine to come online...")
-
-	for {
-		server, err = client.Servers.Details(context.Background(), d.ServerID)
-		if err != nil {
-			return err
-		}
-
-		if server.IsLocked() == false {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-
 	d.IPAddress = server.IPList[0].Address
 
 	return nil


### PR DESCRIPTION
Docker Machine waits for the machine to boot in it's creation sequence. So waiting for the machine to boot in the driver
is unnecessary and interferces with other Docker Machine commands.